### PR TITLE
Add PUT and DELETE organization routes

### DIFF
--- a/src/app/api/organization/[id]/route.ts
+++ b/src/app/api/organization/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import Organization from "@/database/organizationSchema";
+import connectDB from "@/database/db";
+import mongoose from "mongoose";
+
+type UpdateOrganizationBody = {
+  name?: string;
+  description?: string;
+  website?: string;
+  logo?: string;
+  reimbursements?: mongoose.Types.ObjectId[];
+  status?: string;
+};
+
+type IParams = {
+  params: {
+    id: string;
+  };
+};
+
+export async function PUT(req: NextRequest, { params }: IParams) {
+  await connectDB();
+  const { id } = params;
+  const body: UpdateOrganizationBody = await req.json();
+  const { ...updateFields } = body;
+
+  try {
+    const updatedOrganization = await Organization.findByIdAndUpdate(
+      id,
+      updateFields,
+      {
+        new: true,
+        runValidators: true,
+        omitUndefined: true,
+      },
+    );
+    return NextResponse.json(updatedOrganization, { status: 200 });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: `No organization found with the provided ID (${id}) or unable to update`,
+      },
+      { status: 404 },
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: IParams) {
+  await connectDB();
+  const { id } = params;
+
+  const deletedOrganization = await Organization.findByIdAndDelete(id);
+
+  if (!deletedOrganization) {
+    return NextResponse.json(
+      { message: `No organization found with the provided ID ${id}.` },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    { message: `Organization with ID ${id} was successfully deleted.` },
+    { status: 200 },
+  );
+}

--- a/src/app/api/organization/[id]/route.ts
+++ b/src/app/api/organization/[id]/route.ts
@@ -7,6 +7,7 @@ type UpdateOrganizationBody = {
   name?: string;
   description?: string;
   website?: string;
+  clerkUser?: string;
   logo?: string;
   reimbursements?: mongoose.Types.ObjectId[];
   status?: string;
@@ -22,6 +23,9 @@ export async function PUT(req: NextRequest, { params }: IParams) {
   await connectDB();
   const { id } = params;
   const body: UpdateOrganizationBody = await req.json();
+  if (body.hasOwnProperty("clerkUser")) {
+    delete body["clerkUser"];
+  }
   const { ...updateFields } = body;
 
   try {


### PR DESCRIPTION
## Developer: Brandon Wong

Closes #30 

### Pull Request Summary

Created the PUT and DELETE organization routes

### Modifications
`/organization/[id]/route.ts ` - Added the PUT and DELETE routes to update and delete and organization.

### Testing Considerations
Checked routes in Postman
PUT route - Correctly updates given fields. Does not change fields that are not included in received JSON and all fields are optional. Does not edit clerkUser key. Catches errors when invalid ID is given.
DELETE route - Correctly deletes organization by ID. Catches errors when invalid ID is given.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x]  Comments are appropriate
- [x]  The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x]  The summary is completed
- [ ] Assign reviewers

### Notes
- For some reason `findByIdAndUpdate` throws an error when the Id is not valid instead of returning null so I had to use a try catch block instead of checking for `!updatedOrganization`

### Screenshots/Screencast
POST Route
<img width="862" alt="1" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/8e86e014-3d3c-4230-b579-3e96c40010b0">

DELETE Route
<img width="861" alt="Screenshot 2024-02-10 at 2 00 52 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/caea24dd-bd98-46fe-bc84-9a6d62ccc3b2">

