### PR TITLE
Get reimbursements for sponsor table from endpoint

### DIFF
--- a/src/components/sponsored-org-table/columns.tsx
+++ b/src/components/sponsored-org-table/columns.tsx
@@ -43,7 +43,7 @@ export const columns: ColumnDef<Reimbursement>[] = [
     filterFn: "dateFilterFn" as FilterFnOption<Reimbursement>,
     cell: ({ row }) => {
       const date: Date = row.getValue("transactionDate");
-      return date.toLocaleDateString();
+      return new Date(date).toLocaleDateString();
     },
   },
   {

--- a/src/components/sponsored-org-table/sponsored-org-table.tsx
+++ b/src/components/sponsored-org-table/sponsored-org-table.tsx
@@ -1,13 +1,35 @@
 "use client";
 
+import React, { useEffect, useState } from "react";
 import { columns } from "./columns";
 import { DataTable } from "@/components/sponsored-org-table/data-table";
-import { data } from "@/test/mock-data";
 
 export default function SponsoredOrgTable() {
+  const getReimbursementsUrl = "/api/reimbursement";
+  const [reimbursements, setReimbursements] = useState([]);
+
+  useEffect(() => {
+    async function getReimbursements() {
+      try {
+        const response = await fetch(getReimbursementsUrl);
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(
+            `HTTP error. Status: ${response.status}. Error: ${data.error}.`,
+          );
+        }
+        setReimbursements(data);
+      } catch (error) {
+        console.error("Failed to fetch reimbursements:", error);
+      }
+    }
+
+    getReimbursements();
+  }, []);
+
   return (
     <div className="container mx-auto py-10">
-      <DataTable columns={columns} data={data} />
+      <DataTable columns={columns} data={reimbursements} />
     </div>
   );
 }


### PR DESCRIPTION
## Developer: Brandon Wong

Closes #89 

### Pull Request Summary
Replace dummy reimbursement data in sponsor table with data from the database

### Modifications
`src/components/sponsored-org-table/sponsored-org-table.tsx`: Added a fetch to get reimbursement data through endpoint and use it in component
`src/components/sponsored-org-table/columns.tsx`: Edited the way the date is returned to prevent an error

### Testing Considerations
Manually verified that reimbursements from the database shows up in the table 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="1467" alt="Screenshot 2024-03-02 at 1 22 07 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/65729451-acb7-4610-95f0-0f5959fcc071">

