### PR TITLE
#92 collapse sidebar from header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,13 @@
+"use client";
 import type { Metadata } from "next";
 import "@/styles/globals.css";
 import { Inter as FontSans } from "next/font/google";
 import { cn } from "@/lib/utils";
+import { useState } from "react";
+import React from "react";
+import { ClerkProvider } from "@clerk/nextjs";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
-import { ClerkProvider } from "@clerk/nextjs";
 import Sidebar from "@/components/sidebar";
 
 export const fontSans = FontSans({
@@ -12,17 +15,23 @@ export const fontSans = FontSans({
   variable: "--font-sans",
 });
 
-//! Update metadata to match your project
-export const metadata: Metadata = {
-  title: "Ecologistics",
-  description: "Ecologistics Web Portal",
-};
+// may need to be moved elsewhere
+// export const metadata: Metadata = {
+//   title: "Ecologistics",
+//   description: "Ecologistics Web Portal",
+// };
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);
+
+  const toggleSidebar = () => {
+    setIsSidebarCollapsed(!isSidebarCollapsed);
+  };
+
   return (
     <html lang="en">
       <ClerkProvider>
@@ -32,9 +41,12 @@ export default function RootLayout({
             fontSans.variable,
           )}
         >
-          <Header />
+          <Header
+            toggleSidebar={toggleSidebar}
+            isSidebarCollapsed={isSidebarCollapsed}
+          />
           <div className="flex">
-            <Sidebar />
+            <Sidebar isSidebarCollapsed={isSidebarCollapsed} />
             {children}
           </div>
           {/* <Footer /> */}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -13,8 +13,17 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "components/ui/dropdown-menu";
+import { PinLeftIcon, PinRightIcon } from "@radix-ui/react-icons";
 
-export default function Header() {
+type HeaderProps = {
+  toggleSidebar: () => void;
+  isSidebarCollapsed: boolean; // Add this prop definition
+};
+
+export default function Header({
+  toggleSidebar,
+  isSidebarCollapsed,
+}: HeaderProps) {
   const [hasNewUpdates, setHasNewUpdates] = useState(true); // Assume there are new updates initially
 
   const statusUpdates = [
@@ -31,14 +40,28 @@ export default function Header() {
     <nav className="bg-white">
       <div className="py-1">
         <div className="flex justify-between items-center px-5 h-16">
-          <Link href="/">
-            <Image
-              src="/images/ecologistics-logo.svg"
-              alt="Ecologistics Logo"
-              width={216}
-              height={36}
-            />
-          </Link>
+          <div className="flex items-center space-x-4">
+            {/* handles sidebar collapse */}
+            {isSidebarCollapsed ? (
+              <PinLeftIcon
+                className="h-[45px] w-[45px] text-white place-self-end my-2 mr-2 p-2 hover:bg-gray-200 hover:bg-opacity-50 rounded-full cursor-pointer"
+                onClick={toggleSidebar}
+              />
+            ) : (
+              <PinRightIcon
+                className="h-[45px] w-[45px] text-white mx-auto my-2 hover:bg-gray-200 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"
+                onClick={toggleSidebar}
+              />
+            )}
+            <Link href="/">
+              <Image
+                src="/images/ecologistics-logo.svg"
+                alt="Ecologistics Logo"
+                width={216}
+                height={36}
+              />
+            </Link>
+          </div>
           <div className="flex space-x-4">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,7 +17,7 @@ import { PinLeftIcon, PinRightIcon } from "@radix-ui/react-icons";
 
 type HeaderProps = {
   toggleSidebar: () => void;
-  isSidebarCollapsed: boolean; // Add this prop definition
+  isSidebarCollapsed: boolean;
 };
 
 export default function Header({
@@ -37,19 +37,19 @@ export default function Header({
   };
 
   return (
-    <nav className="bg-white">
+    <nav className="bg-orange-100">
       <div className="py-1">
         <div className="flex justify-between items-center px-5 h-16">
           <div className="flex items-center space-x-4">
             {/* handles sidebar collapse */}
             {isSidebarCollapsed ? (
               <PinLeftIcon
-                className="h-[45px] w-[45px] text-white place-self-end my-2 mr-2 p-2 hover:bg-gray-200 hover:bg-opacity-50 rounded-full cursor-pointer"
+                className="h-[45px] w-[45px] text-black place-self-end my-2 mr-2 p-2 hover:bg-gray-100 hover:bg-opacity-50 rounded-full cursor-pointer"
                 onClick={toggleSidebar}
               />
             ) : (
               <PinRightIcon
-                className="h-[45px] w-[45px] text-white mx-auto my-2 hover:bg-gray-200 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"
+                className="h-[45px] w-[45px] text-black mx-auto my-2 hover:bg-gray-100 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"
                 onClick={toggleSidebar}
               />
             )}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -44,7 +44,7 @@ const Sidebar = ({ isSidebarCollapsed }: SidebarProps) => {
   if (!isLoaded || !isSignedIn) {
     return (
       <div
-        className={`flex flex-col h-screen bg-[#335543] ${
+        className={`flex flex-col h-screen pt-4 bg-[#335543] ${
           isSidebarCollapsed ? "w-17" : "w-64"
         }`}
       ></div>
@@ -53,7 +53,7 @@ const Sidebar = ({ isSidebarCollapsed }: SidebarProps) => {
 
   return (
     <div
-      className={`flex flex-col h-screen bg-[#335543] ${
+      className={`flex flex-col h-screen pt-4 bg-[#335543] ${
         isSidebarCollapsed ? "w-17" : "w-64"
       }`}
     >

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,12 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { Nav } from "./nav";
-import {
-  HomeIcon,
-  FileTextIcon,
-  PinLeftIcon,
-  PinRightIcon,
-} from "@radix-ui/react-icons";
+import { HomeIcon, FileTextIcon, ReaderIcon } from "@radix-ui/react-icons";
 import { useUser } from "@clerk/nextjs";
 
 const links = [
@@ -23,9 +18,13 @@ const links = [
   {
     title: "Submit Request",
     route: "/reimbursements",
-    icon: FileTextIcon,
+    icon: ReaderIcon,
   },
 ];
+
+type SidebarProps = {
+  isSidebarCollapsed: boolean;
+};
 
 const selectLink = (user: any) => {
   if (user?.publicMetadata?.admin) {
@@ -39,49 +38,26 @@ const selectLink = (user: any) => {
   }
 };
 
-const Sidebar = () => {
-  const [isCollapsed, setIsCollapsed] = useState(true);
+const Sidebar = ({ isSidebarCollapsed }: SidebarProps) => {
   const { isLoaded, isSignedIn, user } = useUser();
+
   if (!isLoaded || !isSignedIn) {
     return (
       <div
         className={`flex flex-col h-screen bg-[#335543] ${
-          !isCollapsed ? "w-64" : "w-17"
+          isSidebarCollapsed ? "w-17" : "w-64"
         }`}
-      >
-        {isCollapsed ? (
-          <PinRightIcon
-            className="h-[45px] w-[45px] text-white mx-auto my-2 hover:bg-gray-200 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"
-            onClick={() => setIsCollapsed(!isCollapsed)}
-          />
-        ) : (
-          <PinLeftIcon
-            className="h-[45px] w-[45px] text-white place-self-end my-2 mr-2 p-2 hover:bg-gray-200 hover:bg-opacity-50 rounded-full cursor-pointer"
-            onClick={() => setIsCollapsed(!isCollapsed)}
-          />
-        )}
-      </div>
+      ></div>
     );
   }
 
   return (
     <div
       className={`flex flex-col h-screen bg-[#335543] ${
-        !isCollapsed ? "w-64" : "w-17"
+        isSidebarCollapsed ? "w-17" : "w-64"
       }`}
     >
-      {isCollapsed ? (
-        <PinRightIcon
-          className="h-[45px] w-[45px] text-white mx-auto my-2 hover:bg-gray-200 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"
-          onClick={() => setIsCollapsed(!isCollapsed)}
-        />
-      ) : (
-        <PinLeftIcon
-          className="h-[45px] w-[45px] text-white place-self-end my-2 mr-2 p-2 hover:bg-gray-200 hover:bg-opacity-50 rounded-full cursor-pointer"
-          onClick={() => setIsCollapsed(!isCollapsed)}
-        />
-      )}
-      <Nav isCollapsed={isCollapsed} links={selectLink(user) as any[]} />
+      <Nav isCollapsed={isSidebarCollapsed} links={selectLink(user) as any[]} />
     </div>
   );
 };


### PR DESCRIPTION
## Developer: Annes Huynh

Closes #92 

### Pull Request Summary

Moved collapse icon to header and ensured working functionality.

### Modifications

sidebar.tsx - removed pin icon code and logic
header.tsx - added icons, logic, and props
layout.tsx - added toggle function

### Testing Considerations

frontend testing - clicking on icons collapses sidebar properly

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/76940774/773c16b9-9520-45eb-aa40-2dd9c287d3d0)
![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/76940774/617c573d-0b8b-4825-b70a-83fd680cb75f)

