### PR TITLE
Add reimbersement card popup

### DIFF
--- a/src/components/request-info-card.tsx
+++ b/src/components/request-info-card.tsx
@@ -11,7 +11,7 @@ import Reimbursement from "@/database/reimbursement-schema";
 export default function RequestInfoCard(props: Reimbursement) {
   return (
     // Entire Card
-    <Card className="w-2/5 rounded-2xl p-4">
+    <Card className="w-full rounded-2xl p-4">
       {/* Title, status, amount, and date */}
       <CardHeader>
         <div className="flex justify-between items-center">
@@ -20,7 +20,7 @@ export default function RequestInfoCard(props: Reimbursement) {
         </div>
         <CardDescription className="flex space-x-4">
           <div>${props.amount}</div>
-          <div>{props.transactionDate.toLocaleDateString()}</div>
+          <div>{new Date(props.transactionDate).toLocaleDateString()}</div>
         </CardDescription>
       </CardHeader>
       {/* Description, recipient info, and image */}
@@ -34,7 +34,9 @@ export default function RequestInfoCard(props: Reimbursement) {
         </div>
         <div className="flex justify-center">
           <Image
-            src={props.receiptLink}
+            src={
+              "https://ohiostate.pressbooks.pub/app/uploads/sites/160/h5p/content/5/images/image-5bd08790e1864.png" //placeholder, later use: props.receiptLink
+            }
             width={500}
             height={500}
             alt="Receipt Picture"

--- a/src/components/sponsored-org-table/columns.tsx
+++ b/src/components/sponsored-org-table/columns.tsx
@@ -1,9 +1,61 @@
+import React, { useState } from "react";
 import { ColumnDef, FilterFnOption } from "@tanstack/react-table";
 import { DownloadIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import Reimbursement from "@/database/reimbursement-schema";
+import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+import RequestInfoCard from "@/components/request-info-card";
+
+const OrganizationCell = ({ row }: { row: any }) => {
+  const [selectedReimbursement, setSelectedReimbursement] =
+    useState<Reimbursement | null>(null);
+
+  const handleTitleClick = () => {
+    const reimbursementId = row.original._id;
+    fetch(`/api/reimbursement/${reimbursementId}`)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          response.json().then((errorData) => {
+            console.error(errorData.error);
+          });
+        }
+      })
+      .then((data) => {
+        if (data) {
+          setSelectedReimbursement(data);
+        }
+      });
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger>
+        <div className="capitalize" onClick={handleTitleClick}>
+          {row.getValue("reportName")}
+        </div>
+      </DialogTrigger>
+      <DialogContent>
+        <div className="border">
+          {selectedReimbursement ? (
+            <RequestInfoCard {...selectedReimbursement} />
+          ) : (
+            <p>Loading reimbursement information...</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 export const columns: ColumnDef<Reimbursement>[] = [
+  {
+    accessorKey: "organization",
+    header: "Organization",
+    cell: ({ row }) => <OrganizationCell row={row} />,
+  },
+
   {
     accessorKey: "reportName",
     header: "Request",

--- a/src/components/sponsored-org-table/columns.tsx
+++ b/src/components/sponsored-org-table/columns.tsx
@@ -6,7 +6,7 @@ import Reimbursement from "@/database/reimbursement-schema";
 import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 import RequestInfoCard from "@/components/request-info-card";
 
-const OrganizationCell = ({ row }: { row: any }) => {
+const ReportNameCell = ({ row }: { row: any }) => {
   const [selectedReimbursement, setSelectedReimbursement] =
     useState<Reimbursement | null>(null);
 
@@ -51,17 +51,9 @@ const OrganizationCell = ({ row }: { row: any }) => {
 
 export const columns: ColumnDef<Reimbursement>[] = [
   {
-    accessorKey: "organization",
-    header: "Organization",
-    cell: ({ row }) => <OrganizationCell row={row} />,
-  },
-
-  {
     accessorKey: "reportName",
     header: "Request",
-    cell: ({ row }) => (
-      <div className="capitalize">{row.getValue("reportName")}</div>
-    ),
+    cell: ({ row }) => <ReportNameCell row={row} />,
   },
   {
     accessorKey: "recipientName",


### PR DESCRIPTION
## Developer: Brandon Wong

Closes #107 

### Pull Request Summary
Added a feature where clicking a report name in the sponsored org table will open a popup with the reimbursement card. The card and other info in the popup retrieves information from a backend api.

### Modifications
`src/components/request-info-card.tsx`: Changed css to properly show entire reimbursement card. Added placeholder image of reimbursement because data in the receiptLink field are not valid images
`src/components/sponsored-org-table/columns.tsx`: Added function to create a popup and display the RequestInfoCard component when a report name is clicked. This involves retrieving the correct reimbursement from backend api

### Testing Considerations
* Visually verified that clicking a report title creates a popup with information populated from database.
    * Currently shows the same placeholder reimbursement image but can be easily changed to use url from reimbursement's receiptLink field

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/44ea4073-a862-4baf-b766-c0ca5e18bf23


