### PR TITLE
feat: replace blank popup with management request card & connect to be

### DIFF
--- a/src/components/admin-table/columns.tsx
+++ b/src/components/admin-table/columns.tsx
@@ -3,9 +3,60 @@ import { ColumnDef, FilterFnOption } from "@tanstack/react-table";
 import { Badge } from "../ui/badge";
 import { Button } from "@/components/ui/button";
 import { DownloadIcon } from "@radix-ui/react-icons";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 import Reimbursement from "@/database/reimbursement-schema";
+import ManageRequestCard from "../manage-request-card";
+
+const OrganizationCell = ({ row }: { row: any }) => {
+  const [selectedReimbursement, setSelectedReimbursement] =
+    useState<Reimbursement | null>(null);
+
+  useEffect(() => {
+    console.log(row.original);
+  }, []);
+
+  const handleTitleClick = () => {
+    const reimbursementId = row.original._id;
+    fetch(`/api/reimbursement/${reimbursementId}`)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          response.json().then((errorData) => {
+            console.error(errorData.error);
+          });
+        }
+      })
+      .then((data) => {
+        if (data) {
+          setSelectedReimbursement(data);
+        }
+      });
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger>
+        <div className="capitalize" onClick={handleTitleClick}>
+          {row.getValue("organization")}
+        </div>
+      </DialogTrigger>
+      <DialogContent>
+        <div className="border">
+          {selectedReimbursement ? (
+            <ManageRequestCard
+              {...selectedReimbursement}
+              reimbursementId={row.original._id}
+            />
+          ) : (
+            <p>Loading reimbursement information...</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 export const columns: ColumnDef<Reimbursement>[] = [
   {
@@ -14,21 +65,7 @@ export const columns: ColumnDef<Reimbursement>[] = [
   {
     accessorKey: "organization",
     header: "Organization",
-    cell: ({ row }) => (
-      <Dialog>
-        <DialogTrigger>
-          <div className="capitalize">
-            {/* TODO: causes hydration error due to client rendering a different ObjectId than server */}
-            {/* should be fixed when we are rendering organization name instead of id */}
-            {/* {row.getValue<Types.ObjectId>("organization").toString()} */}
-            test org
-          </div>
-        </DialogTrigger>
-        <DialogContent>
-          <div className="border">dialog content</div>
-        </DialogContent>
-      </Dialog>
-    ),
+    cell: ({ row }) => <OrganizationCell row={row} />,
   },
   {
     accessorKey: "recipientName",

--- a/src/components/admin-table/columns.tsx
+++ b/src/components/admin-table/columns.tsx
@@ -4,7 +4,12 @@ import { Badge } from "../ui/badge";
 import { Button } from "@/components/ui/button";
 import { DownloadIcon } from "@radix-ui/react-icons";
 import React, { useEffect, useState } from "react";
-import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogClose,
+} from "@/components/ui/dialog";
 import Reimbursement from "@/database/reimbursement-schema";
 import ManageRequestCard from "../manage-request-card";
 
@@ -16,7 +21,7 @@ const OrganizationCell = ({ row }: { row: any }) => {
     console.log(row.original);
   }, []);
 
-  const handleTitleClick = () => {
+  const fetchReimbursementInfo = () => {
     const reimbursementId = row.original._id;
     fetch(`/api/reimbursement/${reimbursementId}`)
       .then((response) => {
@@ -35,20 +40,40 @@ const OrganizationCell = ({ row }: { row: any }) => {
       });
   };
 
+  const updateComment = (comment: String) => {
+    const reimbursementId = row.original._id;
+    fetch(`/api/reimbursement/${reimbursementId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ comment: comment }),
+    })
+      .then((response) => response.json())
+      .then(() => {
+        fetchReimbursementInfo();
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
   return (
     <Dialog>
       <DialogTrigger>
-        <div className="capitalize" onClick={handleTitleClick}>
+        <div className="capitalize" onClick={fetchReimbursementInfo}>
           {row.getValue("organization")}
         </div>
       </DialogTrigger>
       <DialogContent>
         <div className="border">
           {selectedReimbursement ? (
-            <ManageRequestCard
-              {...selectedReimbursement}
-              reimbursementId={row.original._id}
-            />
+            <>
+              <ManageRequestCard
+                {...selectedReimbursement}
+                updateComment={updateComment}
+              />
+            </>
           ) : (
             <p>Loading reimbursement information...</p>
           )}

--- a/src/components/manage-request-card.tsx
+++ b/src/components/manage-request-card.tsx
@@ -10,29 +10,12 @@ import Image from "next/image";
 import Reimbursement from "@/database/reimbursement-schema";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function ManageRequestCard(
-  props: Reimbursement & { reimbursementId: string },
+  props: Reimbursement & { updateComment: (input: string) => void },
 ) {
-  const [comment, setComment] = useState("");
-
-  const addComment = () => {
-    fetch(`/api/reimbursement/${props.reimbursementId}`, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ comment: props.comment + comment }),
-    })
-      .then((response) => response.json())
-      .then((data) => {
-        console.log(data);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  };
+  const [comment, setComment] = useState(props.comment ?? "");
 
   return (
     // Entire Card
@@ -75,7 +58,12 @@ export default function ManageRequestCard(
             value={comment}
             onChange={(e) => setComment(e.target.value)}
           />
-          <Button className="mt-2" onClick={() => addComment()}>
+          <Button
+            className="mt-2"
+            onClick={() => {
+              props.updateComment(comment);
+            }}
+          >
             Update Comments
           </Button>
         </div>

--- a/src/components/manage-request-card.tsx
+++ b/src/components/manage-request-card.tsx
@@ -10,11 +10,33 @@ import Image from "next/image";
 import Reimbursement from "@/database/reimbursement-schema";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
 
-export default function ManageRequestCard(props: Reimbursement) {
+export default function ManageRequestCard(
+  props: Reimbursement & { reimbursementId: string },
+) {
+  const [comment, setComment] = useState("");
+
+  const addComment = () => {
+    fetch(`/api/reimbursement/${props.reimbursementId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ comment: props.comment + comment }),
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
   return (
     // Entire Card
-    <Card className="m-5 w-2/5 rounded-2xl p-4">
+    <Card className="w-full rounded-2xl p-4">
       {/* Title, status, amount, and date */}
       <CardHeader>
         <div className="flex justify-between items-center">
@@ -23,7 +45,7 @@ export default function ManageRequestCard(props: Reimbursement) {
         </div>
         <CardDescription className="flex space-x-4">
           <div>${props.amount}</div>
-          <div>{props.transactionDate.toLocaleDateString()}</div>
+          <div>{new Date(props.transactionDate).toLocaleDateString()}</div>
         </CardDescription>
       </CardHeader>
       {/* Description, recipient info, and image */}
@@ -35,7 +57,7 @@ export default function ManageRequestCard(props: Reimbursement) {
           {props.recipientName} &nbsp;
           {props.recipientEmail}
           <br></br>
-          {/* missing payment type info from database? */}
+          {/* ssing payment type info from database? */}
           Payment Type Info: {props.paymentMethod}
         </div>
         <div className="flex justify-center mt-[10px]">
@@ -48,8 +70,14 @@ export default function ManageRequestCard(props: Reimbursement) {
           />
         </div>
         <div className="mt-5">
-          <Textarea placeholder="Additional comments" />
-          <Button className="mt-2">Update Comments</Button>
+          <Textarea
+            placeholder="Additional comments"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+          />
+          <Button className="mt-2" onClick={() => addComment()}>
+            Update Comments
+          </Button>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Developer: Vi-Linh Vu

Closes #106 

### Pull Request Summary

Updates popup in admin table to be the Manage Request Card component. Connects info to pull from backend. Also calls PUT request to update comments.

### Modifications
- `src/components/admin-table/columns.tsx`: Replace blank popup with `manage-request-card.tsx` component.
- `src/components/manage-request-card.tsx`: Connect updating comments to backend.

### Testing Considerations
- Tested locally that info from cards were being pulled from backend & matched up
- Locally tested updating the comments. Not sure what behavior we want: Completely replace current comments or just append? Right now it is appending. Also after updating the comments, the results are not immediately shown, you have to click out of the card, and then click back on it.

### Pull Request Checklist

- [X] Code is neat, readable, and works
- [X] Comments are appropriate
- [X] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [X] The developer name is specified
- [X] The summary is completed
- [X] Assign reviewers

### Screenshots/Screencast

<img width="1618" alt="image" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/81380688/751a04a0-844c-44ed-b212-00064c8f4484">
