### PR TITLE
feat: connect sponsored org list page to backend

### DIFF
--- a/src/app/api/organization/route.ts
+++ b/src/app/api/organization/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ErrorResponse } from "@/lib/error";
 import connectDB from "@/database/db";
 import Organization from "@/database/organization-schema";
+import { clerkClient } from "@clerk/nextjs";
 
 export type CreateOrganizationBody = Organization;
 
@@ -9,9 +10,8 @@ export type GetOrganizationsResponse = Organization[];
 export type CreateOrganizationResponse = Organization;
 
 export async function GET(req: NextRequest) {
-  await connectDB(); // function from db.ts before
   try {
-    const organizations: GetOrganizationsResponse = await Organization.find();
+    const organizations = await clerkClient.users.getUserList();
     return NextResponse.json(organizations);
   } catch (error: any) {
     const errorResponse: ErrorResponse = {

--- a/src/app/sponsored-organizations/page.tsx
+++ b/src/app/sponsored-organizations/page.tsx
@@ -92,7 +92,13 @@ async function getOrganizations() {
       throw new Error("Failed to fetch organizations");
     }
     const data = await res.json();
-    return data;
+    const organizations: Organization[] = [];
+    data.forEach((obj: any) => {
+      if (obj.unsafeMetadata.organization) {
+        organizations.push(obj.unsafeMetadata.organization);
+      }
+    });
+    return organizations;
   } catch (err: unknown) {
     console.log(`error: ${err}`);
     return null;
@@ -143,13 +149,15 @@ export default function Page() {
         // Check if org states are empty, and fetch organizations if needed
         if (allOrgs.length === 0) {
           const fetchedOrgs = await getOrganizations();
-          setAllOrgs(fetchedOrgs); // Cache orgs for later
+          if (fetchedOrgs) {
+            setAllOrgs(fetchedOrgs); // Cache orgs for later
 
-          if (fetchedOrgs.length > 0) {
-            const filteredUpdatedOrgs =
-              await filterOrganizationsWithPendingReimbursements(fetchedOrgs); // Fetch organizations with updates
-            console.log(filteredUpdatedOrgs);
-            setUpdatedOrgs(filteredUpdatedOrgs); // Cache orgs for later
+            if (fetchedOrgs.length > 0) {
+              const filteredUpdatedOrgs =
+                await filterOrganizationsWithPendingReimbursements(fetchedOrgs); // Fetch organizations with updates
+              console.log(filteredUpdatedOrgs);
+              setUpdatedOrgs(filteredUpdatedOrgs); // Cache orgs for later
+            }
           }
         }
 

--- a/src/app/sponsored-organizations/page.tsx
+++ b/src/app/sponsored-organizations/page.tsx
@@ -84,6 +84,21 @@ async function filterOrganizationsWithPendingReimbursements(
   return filteredOrgs;
 }
 
+// Fetch list of organizations
+async function getOrganizations() {
+  try {
+    const res = await fetch("/api/organization/");
+    if (!res.ok) {
+      throw new Error("Failed to fetch organizations");
+    }
+    const data = await res.json();
+    return data;
+  } catch (err: unknown) {
+    console.log(`error: ${err}`);
+    return null;
+  }
+}
+
 // Fetch reimbursement info from API
 async function getReimbursement(reimbursementId: string) {
   try {
@@ -127,7 +142,7 @@ export default function Page() {
 
         // Check if org states are empty, and fetch organizations if needed
         if (allOrgs.length === 0) {
-          const fetchedOrgs = organizations; // Replace with proper API fetch
+          const fetchedOrgs = await getOrganizations();
           setAllOrgs(fetchedOrgs); // Cache orgs for later
 
           if (fetchedOrgs.length > 0) {


### PR DESCRIPTION
## Developer: Kim-Linh Vu

Closes #104 

### Pull Request Summary

Connect sponsored org list page with backend, using Clerk API to fetch list of organizations.

### Modifications

- `src/app/api/organization/route.ts`: modified the GET /organization to use the Clerk backend API getUsersList function
- `src/app/sponsored-organizations/page.tsx`: called API route from sponsored org list page instead of using mock data

### Testing Considerations

- tested that GET route was returning data

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1482" alt="Screenshot 2024-04-14 at 12 03 12 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/90161607/c93dccf7-4d9a-4564-ad3f-533e00ea818f">

