### PR TITLE
feat: help menu card

### DIFF
--- a/src/components/admin-table/columns.tsx
+++ b/src/components/admin-table/columns.tsx
@@ -12,6 +12,12 @@ import {
 } from "@/components/ui/dialog";
 import Reimbursement from "@/database/reimbursement-schema";
 import ManageRequestCard from "../manage-request-card";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@radix-ui/react-hover-card";
+import HelpMenu from "../help-menu";
 
 const OrganizationCell = ({ row }: { row: any }) => {
   const [selectedReimbursement, setSelectedReimbursement] =
@@ -130,9 +136,16 @@ export const columns: ColumnDef<Reimbursement>[] = [
     accessorKey: "status",
     header: "Status",
     cell: ({ row }) => (
-      <div className="capitalize">
-        <Badge>{row.getValue("status")}</Badge>
-      </div>
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Button variant="link">
+            <Badge>{row.getValue("status")}</Badge>
+          </Button>
+        </HoverCardTrigger>
+        <HoverCardContent>
+          <HelpMenu />
+        </HoverCardContent>
+      </HoverCard>
     ),
   },
   {

--- a/src/components/help-menu.tsx
+++ b/src/components/help-menu.tsx
@@ -1,56 +1,16 @@
-import { Badge } from "./ui/badge";
+import StatusBadge from "./status-badge";
 import { Card } from "./ui/card";
+import Status from "@/lib/enum";
 
 export default function HelpMenu() {
   return (
     <Card className="flex w-[350px] gap-2 p-2">
       <div className="flex flex-col gap-2">
-        <Badge
-          style={{
-            backgroundColor: "var(--green-bg)",
-            color: "var(--green-text)",
-            width: "fit-content",
-          }}
-        >
-          Paid
-        </Badge>
-
-        <Badge
-          style={{
-            backgroundColor: "var(--orange-bg)",
-            color: "var(--orange-text)",
-            width: "fit-content",
-          }}
-        >
-          On Hold
-        </Badge>
-        <Badge
-          style={{
-            backgroundColor: "var(--blue-bg)",
-            color: "var(--blue-text)",
-            width: "fit-content",
-          }}
-        >
-          Pending
-        </Badge>
-        <Badge
-          style={{
-            backgroundColor: "var(--purple-bg)",
-            color: "var(--purple-text)",
-            width: "fit-content",
-          }}
-        >
-          Review
-        </Badge>
-        <Badge
-          style={{
-            backgroundColor: "var(--red-bg)",
-            color: "var(--red-text)",
-            width: "fit-content",
-          }}
-        >
-          Declined
-        </Badge>
+        <StatusBadge ReimbursementStatus={Status.Paid} />
+        <StatusBadge ReimbursementStatus={Status.OnHold} />
+        <StatusBadge ReimbursementStatus={Status.Pending} />
+        <StatusBadge ReimbursementStatus={Status.NeedsReview} />
+        <StatusBadge ReimbursementStatus={Status.Declined} />
       </div>
       <div className="flex flex-col gap-2.5 text-left">
         <span>Request has been paid</span>

--- a/src/components/help-menu.tsx
+++ b/src/components/help-menu.tsx
@@ -1,0 +1,64 @@
+import { Badge } from "./ui/badge";
+import { Card } from "./ui/card";
+
+export default function HelpMenu() {
+  return (
+    <Card className="flex w-[350px] gap-2 p-2">
+      <div className="flex flex-col gap-2">
+        <Badge
+          style={{
+            backgroundColor: "var(--green-bg)",
+            color: "var(--green-text)",
+            width: "fit-content",
+          }}
+        >
+          Paid
+        </Badge>
+
+        <Badge
+          style={{
+            backgroundColor: "var(--orange-bg)",
+            color: "var(--orange-text)",
+            width: "fit-content",
+          }}
+        >
+          On Hold
+        </Badge>
+        <Badge
+          style={{
+            backgroundColor: "var(--blue-bg)",
+            color: "var(--blue-text)",
+            width: "fit-content",
+          }}
+        >
+          Pending
+        </Badge>
+        <Badge
+          style={{
+            backgroundColor: "var(--purple-bg)",
+            color: "var(--purple-text)",
+            width: "fit-content",
+          }}
+        >
+          Review
+        </Badge>
+        <Badge
+          style={{
+            backgroundColor: "var(--red-bg)",
+            color: "var(--red-text)",
+            width: "fit-content",
+          }}
+        >
+          Declined
+        </Badge>
+      </div>
+      <div className="flex flex-col gap-2.5 text-left">
+        <span>Request has been paid</span>
+        <span>Request has missing information</span>
+        <span>Awaiting admin to fulfill payment</span>
+        <span>Awaiting admin review</span>
+        <span>Request was declined</span>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -9,7 +9,7 @@ function choosingTheBadge(ReimbursementStatus: Status) {
       return (
         <Badge
           variant="status"
-          className="bg-blue-200 font-medium text-blue-800"
+          className="bg-blue-200 font-medium text-blue-800 w-fit"
         >
           Pending
         </Badge>
@@ -18,7 +18,7 @@ function choosingTheBadge(ReimbursementStatus: Status) {
       return (
         <Badge
           variant="status"
-          className="bg-gray-100 font-medium text-gray-700"
+          className="bg-gray-100 font-medium text-gray-700 w-fit"
         >
           Needs Review
         </Badge>
@@ -27,14 +27,17 @@ function choosingTheBadge(ReimbursementStatus: Status) {
       return (
         <Badge
           variant="status"
-          className="bg-orange-100 font-medium text-orange-900"
+          className="bg-orange-100 font-medium text-orange-900 w-fit"
         >
           On Hold
         </Badge>
       );
     case Status.Declined:
       return (
-        <Badge variant="status" className="bg-red-100 font-medium text-red-900">
+        <Badge
+          variant="status"
+          className="bg-red-100 font-medium text-red-900 w-fit"
+        >
           Declined
         </Badge>
       );
@@ -42,7 +45,7 @@ function choosingTheBadge(ReimbursementStatus: Status) {
       return (
         <Badge
           variant="status"
-          className="bg-green-100 font-medium text-green-900"
+          className="bg-green-100 font-medium text-green-900 w-fit"
         >
           Paid
         </Badge>
@@ -51,7 +54,7 @@ function choosingTheBadge(ReimbursementStatus: Status) {
       return (
         <Badge
           variant="status"
-          className=" bg-orange-400 font-medium text-red-800"
+          className=" bg-orange-400 font-medium text-red-800 fit-content w-fit"
         >
           ERROR
         </Badge>
@@ -59,6 +62,12 @@ function choosingTheBadge(ReimbursementStatus: Status) {
   }
 }
 
-export default function StatusBadge(ReimbursementStatus: Status) {
-  return <div>{choosingTheBadge(ReimbursementStatus)}</div>;
+interface StatusBadgeProps {
+  ReimbursementStatus: Status;
 }
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({ ReimbursementStatus }) => {
+  return <>{choosingTheBadge(ReimbursementStatus)}</>;
+};
+
+export default StatusBadge;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,6 +33,17 @@
     --ring: 0 0% 3.9%;
 
     --radius: 0.5rem;
+
+    --green-bg: #e4f4ed;
+    --green-text: #285435;
+    --orange-bg: #faefe3;
+    --orange-text: #926333;
+    --blue-bg: #d8eafd;
+    --blue-text: #21508c;
+    --purple-bg: #ddcdf3;
+    --purple-text: #3b1671;
+    --red-bg: #f3e1e2;
+    --red-text: #903534;
   }
 
   .dark {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,17 +33,6 @@
     --ring: 0 0% 3.9%;
 
     --radius: 0.5rem;
-
-    --green-bg: #e4f4ed;
-    --green-text: #285435;
-    --orange-bg: #faefe3;
-    --orange-text: #926333;
-    --blue-bg: #d8eafd;
-    --blue-text: #21508c;
-    --purple-bg: #ddcdf3;
-    --purple-text: #3b1671;
-    --red-bg: #f3e1e2;
-    --red-text: #903534;
   }
 
   .dark {


### PR DESCRIPTION
## Developer: Vi-Linh Vu

Closes #122 

### Pull Request Summary

Created help menu component. 

### Modifications
- `src/components/help-menu.tsx`: Help menu component
- `src/styles/globals.css`: Added color values used in badges, assuming they will be used elsewhere (eg the tables).
- `src/components/admin-table/columns.tsx`: Added help menu component to appear on hover over Admin Table status badges.

### Testing Considerations

Viewed component locally. Modified it to look more aligned when inserted in HoverCardContent component because I'm assuming that's the purpose of it (having it as a child of the HoverCardContent component messes with the styling. Component itself is not aligned if just rendered on its own. (See screenshots)

### Pull Request Checklist

- [X] Code is neat, readable, and works
- [X] Comments are appropriate
- [X] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [X] The developer name is specified
- [X] The summary is completed
- [X] Assign reviewers

### Screenshots/Screencast

<img width="371" alt="Screenshot 2024-04-20 at 8 05 39 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/81380688/42025c6e-be59-450b-8747-e7c8be0e0d91">

Component on its own (content is not lined up)

<img width="703" alt="Screenshot 2024-04-20 at 8 05 23 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/81380688/aee9b31d-84a9-4111-86b0-15144f411d38">

Component when hovering over badge in table