### PR TITLE
Update admin and sponsored org tables to use status badges john ieng

### DIFF
--- a/src/components/admin-table/columns.tsx
+++ b/src/components/admin-table/columns.tsx
@@ -1,6 +1,6 @@
 import { formatAmount } from "@/lib/format";
 import { ColumnDef, FilterFnOption } from "@tanstack/react-table";
-import { Badge } from "../ui/badge";
+import StatusBadge from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 import { DownloadIcon } from "@radix-ui/react-icons";
 import React, { useEffect, useState } from "react";
@@ -131,7 +131,7 @@ export const columns: ColumnDef<Reimbursement>[] = [
     header: "Status",
     cell: ({ row }) => (
       <div className="capitalize">
-        <Badge>{row.getValue("status")}</Badge>
+        <StatusBadge reimbursementStatus={row.getValue("status")} />
       </div>
     ),
   },

--- a/src/components/sponsored-org-table/columns.tsx
+++ b/src/components/sponsored-org-table/columns.tsx
@@ -7,9 +7,6 @@ import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 import RequestInfoCard from "@/components/request-info-card";
 import StatusBadge from "@/components/status-badge";
 
-function testFunc(status: any) {
-  console.log(typeof status);
-}
 const ReportNameCell = ({ row }: { row: any }) => {
   const [selectedReimbursement, setSelectedReimbursement] =
     useState<Reimbursement | null>(null);

--- a/src/components/sponsored-org-table/columns.tsx
+++ b/src/components/sponsored-org-table/columns.tsx
@@ -5,7 +5,11 @@ import { Button } from "@/components/ui/button";
 import Reimbursement from "@/database/reimbursement-schema";
 import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 import RequestInfoCard from "@/components/request-info-card";
+import StatusBadge from "@/components/status-badge";
 
+function testFunc(status: any) {
+  console.log(typeof status);
+}
 const ReportNameCell = ({ row }: { row: any }) => {
   const [selectedReimbursement, setSelectedReimbursement] =
     useState<Reimbursement | null>(null);
@@ -78,7 +82,9 @@ export const columns: ColumnDef<Reimbursement>[] = [
     accessorKey: "status",
     header: "Status",
     cell: ({ row }) => (
-      <div className="capitalize">{row.getValue("status")}</div>
+      <div className="capitalize">
+        <StatusBadge reimbursementStatus={row.getValue("status")} />
+      </div>
     ),
   },
   {

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -3,8 +3,8 @@
 import Status from "@/lib/enum";
 import { Badge } from "@/components/ui/badge";
 
-function choosingTheBadge(ReimbursementStatus: Status) {
-  switch (ReimbursementStatus) {
+function choosingTheBadge(reimbursementStatus: Status) {
+  switch (reimbursementStatus) {
     case Status.Pending:
       return (
         <Badge
@@ -59,6 +59,10 @@ function choosingTheBadge(ReimbursementStatus: Status) {
   }
 }
 
-export default function StatusBadge(ReimbursementStatus: Status) {
-  return <div>{choosingTheBadge(ReimbursementStatus)}</div>;
+interface StatusBadgeProps {
+  reimbursementStatus: Status;
+}
+
+export default function StatusBadge(props: StatusBadgeProps) {
+  return <div>{choosingTheBadge(props.reimbursementStatus)}</div>;
 }

--- a/src/lib/enum.ts
+++ b/src/lib/enum.ts
@@ -4,6 +4,5 @@ enum Status {
   OnHold = "ON_HOLD",
   Declined = "DECLINED",
   Paid = "PAID",
-  Archived = "ARCHIVED",
 }
 export default Status;


### PR DESCRIPTION
## Developer: John Ieng

Closes #82

### Pull Request Summary

Update the admin and sponsored org tables to use the status badge component

### Modifications

`/src/components/status-badge.tsx`: Fix handling of prop type
`/src/components/sponsored-org-table/columns.tsx`: Replaced current badge with status badge component
`/src/components/admin-table/columns.tsx`: Replaced current badge with status badge component

### Testing Considerations

Rendered both tables and used invalid input to make sure enum validation worked, also messed with filtering to make sure no other functionality was broken.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

Admin Table:
![Screenshot 2024-04-21 at 3 56 53 PM](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/70654142/7498e87d-daae-444d-9978-aeee987acc99)


Sponsored Organization Table:
![Screenshot 2024-04-21 at 3 56 28 PM](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/70654142/573062c4-1196-44c5-8bc2-3d9240e62bb2)



