### PR TITLE
Update header, sidebar, sponsored org home page styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import SponsoredOrgTable from "@/components/sponsored-org-table/sponsored-org-ta
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import CenteredSpinner from "@/components/centered-spinner";
+import SponsoredHomePage from "./sponsored-home/SponsoredHomePage";
 
 export default function Home() {
   const router = useRouter();
@@ -39,7 +40,7 @@ export default function Home() {
           }
         )?.approved
       ) {
-        return router.push("/sponsored-home");
+        return <SponsoredHomePage />;
       } else {
         return (
           <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,6 @@ import SponsoredOrgTable from "@/components/sponsored-org-table/sponsored-org-ta
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import CenteredSpinner from "@/components/centered-spinner";
-import Popup from "@/components/user-info-popup";
-
-type organizationInfo = {
-  name: string;
-  description: string;
-  website: string;
-  approved: boolean;
-};
 
 export default function Home() {
   const router = useRouter();
@@ -47,19 +39,7 @@ export default function Home() {
           }
         )?.approved
       ) {
-        const orgInfo = user?.unsafeMetadata?.organization as organizationInfo;
-        return (
-          <main>
-            <Popup
-              name={orgInfo.name}
-              description={orgInfo.description}
-              website={orgInfo.website}
-              email={(user?.primaryEmailAddress?.emailAddress as string) || ""}
-              user={(user?.fullName as string) || ""}
-            />
-            <SponsoredOrgTable />
-          </main>
-        );
+        return router.push("/sponsored-home");
       } else {
         return (
           <>

--- a/src/app/sponsored-home/SponsoredHomePage.tsx
+++ b/src/app/sponsored-home/SponsoredHomePage.tsx
@@ -6,6 +6,7 @@ import Popup from "@/components/user-info-popup";
 import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import * as Tabs from "@radix-ui/react-tabs";
+import { Button } from "@/components/ui/button";
 
 type organizationInfo = {
   name: string;
@@ -14,7 +15,7 @@ type organizationInfo = {
   approved: boolean;
 };
 
-export default function Page() {
+export default function SponsoredHomePage() {
   const router = useRouter();
   const { isLoaded, isSignedIn, user } = useUser();
 
@@ -26,10 +27,12 @@ export default function Page() {
     );
   }
   if (!isSignedIn) {
-    return router.push("/sign-in");
+    router.push("/sign-in");
+    return;
   }
   if (!user?.unsafeMetadata?.organization) {
-    return router.push("/setup-organization");
+    router.push("/setup-organization");
+    return;
   }
 
   const orgInfo = user?.unsafeMetadata?.organization as organizationInfo;
@@ -63,7 +66,13 @@ export default function Page() {
             </Tabs.Trigger>
           </Tabs.List>
 
-          <div className="py-1">
+          <div className="flex flex-col mt-4">
+            <Button
+              onClick={() => router.push("/reimbursements")}
+              className="bg-orange-500 text-[16px] font-[600] place-self-end"
+            >
+              Request Reimbursement
+            </Button>
             <Tabs.Content value="all">
               <SponsoredOrgTable />
             </Tabs.Content>

--- a/src/app/sponsored-home/page.tsx
+++ b/src/app/sponsored-home/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import CenteredSpinner from "@/components/centered-spinner";
+import SponsoredOrgTable from "@/components/sponsored-org-table/sponsored-org-table";
+import Popup from "@/components/user-info-popup";
+import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import * as Tabs from "@radix-ui/react-tabs";
+
+type organizationInfo = {
+  name: string;
+  description: string;
+  website: string;
+  approved: boolean;
+};
+
+export default function Page() {
+  const router = useRouter();
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  if (!isLoaded) {
+    return (
+      <div>
+        <CenteredSpinner />
+      </div>
+    );
+  }
+  if (!isSignedIn) {
+    return router.push("/sign-in");
+  }
+  if (!user?.unsafeMetadata?.organization) {
+    return router.push("/setup-organization");
+  }
+
+  const orgInfo = user?.unsafeMetadata?.organization as organizationInfo;
+
+  return (
+    <main className="px-14 py-12 h-screen overflow-y-auto w-full">
+      <div className="flex gap-x-6 items-center">
+        <h1 className="font-bold text-4xl">{orgInfo.name}</h1>
+        <Popup
+          name={orgInfo.name}
+          description={orgInfo.description}
+          website={orgInfo.website}
+          email={(user?.primaryEmailAddress?.emailAddress as string) || ""}
+          user={(user?.fullName as string) || ""}
+        />
+      </div>
+      <div className="flex flex-col mt-8">
+        <Tabs.Root defaultValue="all">
+          <Tabs.List className="flex gap-x-2 border-b border-gray-500">
+            <Tabs.Trigger
+              className="text-[15px] px-1 pb-1 font-[500] hover:text-orange-500 data-[state=active]:text-orange-500 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=active]:shadow-current outline-none cursor-pointer"
+              value="all"
+            >
+              All Requests
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              className="text-[15px] px-1 pb-1 font-[500] hover:text-orange-500 data-[state=active]:text-orange-500 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=active]:shadow-current outline-none cursor-pointer"
+              value="archived"
+            >
+              Archived Requests
+            </Tabs.Trigger>
+          </Tabs.List>
+
+          <div className="py-1">
+            <Tabs.Content value="all">
+              <SponsoredOrgTable />
+            </Tabs.Content>
+
+            <Tabs.Content value="archived"></Tabs.Content>
+          </div>
+        </Tabs.Root>
+      </div>
+    </main>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { BellIcon } from "@radix-ui/react-icons";
-import { UserButton } from "@clerk/nextjs";
+import { UserButton, useUser } from "@clerk/nextjs";
 import Link from "next/link";
 import Image from "next/image";
 import {
@@ -16,6 +16,7 @@ import {
 
 export default function Header() {
   const [hasNewUpdates, setHasNewUpdates] = useState(true); // Assume there are new updates initially
+  const { user } = useUser();
 
   const statusUpdates = [
     { id: 1, text: "Request A approved" },
@@ -28,9 +29,9 @@ export default function Header() {
   };
 
   return (
-    <nav className="bg-white">
-      <div className="py-1">
-        <div className="flex justify-between items-center px-5 h-16">
+    <nav className="bg-[#EDEBDA]">
+      <div className="py-1.5">
+        <div className="flex justify-between items-center px-7 h-16">
           <Link href="/">
             <Image
               src="/images/ecologistics-logo.svg"
@@ -39,28 +40,31 @@ export default function Header() {
               height={36}
             />
           </Link>
-          <div className="flex space-x-4">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button onClick={handleDropdownOpen}>
-                  <div className="relative">
-                    <BellIcon className="w-6 h-6" />
-                    {hasNewUpdates && <span className="badge"></span>}
-                  </div>
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="right-0">
-                <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {statusUpdates.map((statusUpdate) => (
-                  <DropdownMenuItem key={statusUpdate.id}>
-                    {statusUpdate.text}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <UserButton />
-          </div>
+          {user && (
+            <div className="flex gap-x-8">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button onClick={handleDropdownOpen}>
+                    <div className="relative">
+                      <BellIcon className="w-6 h-6" />
+                      {hasNewUpdates && <span className="badge"></span>}
+                    </div>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="right-0">
+                  <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {statusUpdates.map((statusUpdate) => (
+                    <DropdownMenuItem key={statusUpdate.id}>
+                      {statusUpdate.text}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <UserButton />
+            </div>
+          )}
         </div>
       </div>
       <style jsx>{`

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -21,20 +21,26 @@ export function Nav({ links, isCollapsed }: NavProps) {
     return path === pathname;
   };
   return (
-    <nav className="flex flex-col gap-4 px-2">
+    <nav
+      className={`flex flex-col gap-y-4 ${isCollapsed ? "px-4" : "pl-4 w-[200px]"}`}
+    >
       {links.map((link, index) => (
         <Link
           key={index}
           href={link.route}
           className={cn(
             buttonVariants({ variant: "ghost", size: "sm" }),
-            "justify-start rounded-lg py-6 hover:text-[#F18030] text-white",
-            !isCollapsed && "w-60",
-            isItemActive(link.route) && "text-[#F18030] bg-accent",
+            "justify-start py-6 rounded-xl text-white hover:bg-gray-200 hover:bg-opacity-50 hover:text-white",
+            !isCollapsed && "w-55 rounded-tr-none rounded-br-none",
+            isItemActive(link.route) && "bg-gray-200 bg-opacity-50",
           )}
         >
           <link.icon className="h-[25px] w-[25px]" />
-          {!isCollapsed && <span className="text-base ml-5">{link.title}</span>}
+          {!isCollapsed && (
+            <span className="text-base ml-3 font-[650] text-[18px]">
+              {link.title}
+            </span>
+          )}
         </Link>
       ))}
     </nav>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -6,6 +6,7 @@ import {
   FileTextIcon,
   PinLeftIcon,
   PinRightIcon,
+  DashboardIcon,
 } from "@radix-ui/react-icons";
 import { useUser } from "@clerk/nextjs";
 
@@ -16,12 +17,12 @@ const links = [
     icon: HomeIcon,
   },
   {
-    title: "Sponsored Organizations",
+    title: "Sponsors",
     route: "/sponsored-organizations",
-    icon: FileTextIcon,
+    icon: DashboardIcon,
   },
   {
-    title: "Submit Request",
+    title: "Requests",
     route: "/reimbursements",
     icon: FileTextIcon,
   },
@@ -44,11 +45,7 @@ const Sidebar = () => {
   const { isLoaded, isSignedIn, user } = useUser();
   if (!isLoaded || !isSignedIn) {
     return (
-      <div
-        className={`flex flex-col h-screen bg-[#335543] ${
-          !isCollapsed ? "w-64" : "w-17"
-        }`}
-      >
+      <div className={`flex flex-col min-w-[81px] h-screen bg-[#335543]`}>
         {isCollapsed ? (
           <PinRightIcon
             className="h-[45px] w-[45px] text-white mx-auto my-2 hover:bg-gray-200 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"
@@ -65,11 +62,7 @@ const Sidebar = () => {
   }
 
   return (
-    <div
-      className={`flex flex-col h-screen bg-[#335543] ${
-        !isCollapsed ? "w-64" : "w-17"
-      }`}
-    >
+    <div className="flex flex-col h-screen bg-[#335543]">
       {isCollapsed ? (
         <PinRightIcon
           className="h-[45px] w-[45px] text-white mx-auto my-2 hover:bg-gray-200 hover:bg-opacity-50 p-2 rounded-full cursor-pointer"

--- a/src/components/sponsored-org-table/sponsored-org-table.tsx
+++ b/src/components/sponsored-org-table/sponsored-org-table.tsx
@@ -27,9 +27,5 @@ export default function SponsoredOrgTable() {
     getReimbursements();
   }, []);
 
-  return (
-    <div className="container mx-auto py-10">
-      <DataTable columns={columns} data={reimbursements} />
-    </div>
-  );
+  return <DataTable columns={columns} data={reimbursements} />;
 }


### PR DESCRIPTION
## Developer: Kim-Linh Vu

Closes #125 

### Pull Request Summary

Update the style of header, sidebar, and sponsored org home page to match figma design.

### Modifications

- src/components/header.tsx: updated background color and only render user button if user is logged in
- src/components/nav.tsx: updated styling and hover/focus colors 
- src/components/sidebar.tsx: updated styling
- src/app/page.tsx: added new route to /sponsored-home page
- src/app/sponsored-home/page.tsx: created new page for sponsored org home page

### Testing Considerations

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1505" alt="Screenshot 2024-04-28 at 9 30 27 AM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/90161607/920e00bc-4277-4999-b42c-a8684602aad3">

<img width="1502" alt="Screenshot 2024-04-28 at 9 49 31 AM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/90161607/77ffa780-3378-4ab8-803f-d88116b805e4">

<img width="1504" alt="Screenshot 2024-04-28 at 9 49 42 AM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/90161607/d0d71777-2be7-4c2b-83ab-6691bcc5bd97">
