### PR TITLE
Finalize authentication flow

### DIFF
--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,12 @@
+import FullscreenSpinner from "@/components/fullscreen-spinner";
 import { SignIn } from "@clerk/nextjs";
 
 export default function Page() {
-  return <SignIn />;
+  return (
+    <div className="w-screen h-screen fixed top-0 left-0 z-0">
+      <div className="w-full h-screen flex justify-center items-center">
+        <SignIn />
+      </div>
+    </div>
+  );
 }

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,5 +1,11 @@
 import { SignUp } from "@clerk/nextjs";
 
 export default function Page() {
-  return <SignUp></SignUp>;
+  return (
+    <div className="w-screen h-screen fixed top-0 left-0 z-0">
+      <div className="w-full h-screen flex justify-center items-center">
+        <SignUp />
+      </div>
+    </div>
+  );
 }

--- a/src/components/alert-dropdown.tsx
+++ b/src/components/alert-dropdown.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { BellIcon } from "@radix-ui/react-icons";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "components/ui/dropdown-menu";
+import NewUserButton from "./user-button";
+import { useUser } from "@clerk/nextjs";
+
+// Alert component on header
+export default function Alert() {
+  const { isSignedIn } = useUser();
+  const [hasNewUpdates, setHasNewUpdates] = useState(true); // Assume there are new updates initially
+
+  const statusUpdates = [
+    { id: 1, text: "Request A approved" },
+    { id: 2, text: "Request B approved" },
+    { id: 3, text: "Request C denied" },
+  ];
+
+  const handleDropdownOpen = () => {
+    setHasNewUpdates(false); // Resets the new updates state when dropdown is opened
+  };
+  // Show if logged in
+  if (isSignedIn) {
+    return (
+      <div className="z-10">
+        <div className="flex space-x-4">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button onClick={handleDropdownOpen}>
+                <div className="relative">
+                  <BellIcon className="w-6 h-6" />
+                  {hasNewUpdates && <span className="badge"></span>}
+                </div>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="right-0">
+              <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {statusUpdates.map((statusUpdate) => (
+                <DropdownMenuItem key={statusUpdate.id}>
+                  {statusUpdate.text}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <NewUserButton />
+        </div>
+        <style jsx>{`
+          .badge {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 8px;
+            height: 8px;
+            background-color: red;
+            border-radius: 50%;
+          }
+        `}</style>
+      </div>
+    );
+  }
+  // Hide if logged out
+  else {
+    return null;
+  }
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import { BellIcon } from "@radix-ui/react-icons";
-import { UserButton } from "@clerk/nextjs";
+import { UserButton, UserProfile } from "@clerk/nextjs";
 import Link from "next/link";
 import Image from "next/image";
+import { useUser } from "@clerk/nextjs";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -13,8 +14,10 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "components/ui/dropdown-menu";
+import NewUserButton from "./user-button";
 
-export default function Header() {
+// Alert component on header
+function Alert({ isLoggedIn }: { isLoggedIn: boolean | undefined }) {
   const [hasNewUpdates, setHasNewUpdates] = useState(true); // Assume there are new updates initially
 
   const statusUpdates = [
@@ -26,12 +29,60 @@ export default function Header() {
   const handleDropdownOpen = () => {
     setHasNewUpdates(false); // Resets the new updates state when dropdown is opened
   };
+  // Show if logged in
+  if (isLoggedIn) {
+    return (
+      <div className="z-10">
+        <div className="flex space-x-4">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button onClick={handleDropdownOpen}>
+                <div className="relative">
+                  <BellIcon className="w-6 h-6" />
+                  {hasNewUpdates && <span className="badge"></span>}
+                </div>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="right-0">
+              <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {statusUpdates.map((statusUpdate) => (
+                <DropdownMenuItem key={statusUpdate.id}>
+                  {statusUpdate.text}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <NewUserButton />
+        </div>
+        <style jsx>{`
+          .badge {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 8px;
+            height: 8px;
+            background-color: red;
+            border-radius: 50%;
+          }
+        `}</style>
+      </div>
+    );
+  }
+  // Hide if logged out
+  else {
+    return null;
+  }
+}
 
+export default function Header() {
+  const { isSignedIn } = useUser();
   return (
-    <nav className="bg-white">
+    <nav>
       <div className="py-1">
         <div className="flex justify-between items-center px-5 h-16">
-          <Link href="/">
+          {/* Priotize header link */}
+          <Link href="/" className="z-10">
             <Image
               src="/images/ecologistics-logo.svg"
               alt="Ecologistics Logo"
@@ -39,41 +90,9 @@ export default function Header() {
               height={36}
             />
           </Link>
-          <div className="flex space-x-4">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button onClick={handleDropdownOpen}>
-                  <div className="relative">
-                    <BellIcon className="w-6 h-6" />
-                    {hasNewUpdates && <span className="badge"></span>}
-                  </div>
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="right-0">
-                <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {statusUpdates.map((statusUpdate) => (
-                  <DropdownMenuItem key={statusUpdate.id}>
-                    {statusUpdate.text}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <UserButton />
-          </div>
+          <Alert isLoggedIn={isSignedIn} />
         </div>
       </div>
-      <style jsx>{`
-        .badge {
-          position: absolute;
-          top: 0;
-          right: 0;
-          width: 8px;
-          height: 8px;
-          background-color: red;
-          border-radius: 50%;
-        }
-      `}</style>
     </nav>
   );
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,82 +1,8 @@
-"use client";
-
-import { useState } from "react";
-import { BellIcon } from "@radix-ui/react-icons";
-import { UserButton, UserProfile } from "@clerk/nextjs";
 import Link from "next/link";
 import Image from "next/image";
-import { useUser } from "@clerk/nextjs";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-} from "components/ui/dropdown-menu";
-import NewUserButton from "./user-button";
-
-// Alert component on header
-function Alert({ isLoggedIn }: { isLoggedIn: boolean | undefined }) {
-  const [hasNewUpdates, setHasNewUpdates] = useState(true); // Assume there are new updates initially
-
-  const statusUpdates = [
-    { id: 1, text: "Request A approved" },
-    { id: 2, text: "Request B approved" },
-    { id: 3, text: "Request C denied" },
-  ];
-
-  const handleDropdownOpen = () => {
-    setHasNewUpdates(false); // Resets the new updates state when dropdown is opened
-  };
-  // Show if logged in
-  if (isLoggedIn) {
-    return (
-      <div className="z-10">
-        <div className="flex space-x-4">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button onClick={handleDropdownOpen}>
-                <div className="relative">
-                  <BellIcon className="w-6 h-6" />
-                  {hasNewUpdates && <span className="badge"></span>}
-                </div>
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="right-0">
-              <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {statusUpdates.map((statusUpdate) => (
-                <DropdownMenuItem key={statusUpdate.id}>
-                  {statusUpdate.text}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <NewUserButton />
-        </div>
-        <style jsx>{`
-          .badge {
-            position: absolute;
-            top: 0;
-            right: 0;
-            width: 8px;
-            height: 8px;
-            background-color: red;
-            border-radius: 50%;
-          }
-        `}</style>
-      </div>
-    );
-  }
-  // Hide if logged out
-  else {
-    return null;
-  }
-}
+import Alert from "./alert-dropdown";
 
 export default function Header() {
-  const { isSignedIn } = useUser();
   return (
     <nav>
       <div className="py-1">
@@ -90,7 +16,7 @@ export default function Header() {
               height={36}
             />
           </Link>
-          <Alert isLoggedIn={isSignedIn} />
+          <Alert />
         </div>
       </div>
     </nav>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -42,7 +42,11 @@ const selectLink = (user: any) => {
 const Sidebar = () => {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const { isLoaded, isSignedIn, user } = useUser();
-  if (!isLoaded || !isSignedIn) {
+  // Don't render sidebar when not logged in
+  if (!isSignedIn) {
+    return null;
+  }
+  if (!isLoaded) {
     return (
       <div
         className={`flex flex-col h-screen bg-[#335543] ${

--- a/src/components/user-button.tsx
+++ b/src/components/user-button.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { UserProfile, useClerk, useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { ChevronDownIcon, Cross2Icon } from "@radix-ui/react-icons";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import Image from "next/image";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export default function NewUserButton() {
+  const { isSignedIn, user } = useUser();
+  const [showUserProfile, setShowUserProfile] = useState(false);
+  const { signOut } = useClerk();
+  const router = useRouter();
+
+  // Open Profile
+  const handleManageAccountClick = () => {
+    setShowUserProfile(true);
+  };
+  // Close Profile
+  const handleExitUserProfile = () => {
+    setShowUserProfile(false);
+  };
+
+  if (isSignedIn) {
+    return (
+      <div className="flex">
+        <DropdownMenu>
+          <DropdownMenuTrigger className="hover:bg-[#DDD9C0] rounded-md">
+            <div className="flex max-h-8 m-4 items-center">
+              <Image
+                src={user.imageUrl}
+                alt="User Profile Picture"
+                width={32}
+                height={32}
+                className="rounded-full max-w-8 max-h-8"
+              />
+              <div className="flex flex-col max-h-8 mx-3">
+                <div className="text-sm leading-4 font-semibold text-start">
+                  {user.fullName}
+                </div>
+                <div className="text-xs leading-4 font-light text-start">
+                  {user.primaryEmailAddress?.emailAddress}
+                </div>
+              </div>
+              <ChevronDownIcon className="w-auto h-5 ml-2" />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-60">
+            <DropdownMenuItem onClick={handleManageAccountClick}>
+              Manage account
+            </DropdownMenuItem>
+            {/* Routes Sign Out to '/' */}
+            <DropdownMenuItem onClick={() => signOut(() => router.push("/"))}>
+              Sign out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {/* Show profile similar to Clerk's deafult UserButton */}
+        {showUserProfile && (
+          <div className="fixed inset-0 flex justify-center items-center z-50 bg-gray-800 bg-opacity-50">
+            <div className="flex h-3/4">
+              <UserProfile
+                appearance={{
+                  elements: {
+                    rootBox: "h-full",
+                  },
+                }}
+              />
+              {/* Exit button for User Profile */}
+              <div className="relative right-20 top-4">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="w-8 h-8 flex justify-center items-center rounded-lg"
+                  onClick={handleExitUserProfile}
+                >
+                  <Cross2Icon />
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  } else {
+    return null;
+  }
+}


### PR DESCRIPTION
## Developer: Peter Chinh

Closes #136 

### Pull Request Summary

Hide sidebar and alerts when not logged in, style the user profile on header according to Figma, centered sign in/up card, sign out redirects to '/'

### Modifications
src\app\sign-in\[[...sign-in]]\page.tsx - Centered sign in to page
src\app\sign-up\[[...sign-up]]\page.tsx - Centered sign up to page
src\components\sidebar.tsx - Return null when not signed in
src\components\user-button.tsx - New user button component that mimics Clerk's default user button
src\components\header.tsx - Moved alerts to a new function, made it so it returns null when not signed in, and implemented NewUserButton

### Testing Considerations

Go to sign in page and the card should be centered. There should be no side bar and alerts. Then login and side bar, alerts, and user button should appear. Sign out with new user button and be redirected to where '/' routes to.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/113927794/57de08ae-5813-4db7-b260-a5557b709317)
![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/113927794/bbdd9370-e528-4172-b3f7-3c58c78986f1)
