### PR TITLE
Use reimbursement receipt link field

### DIFF
--- a/src/components/request-info-card.tsx
+++ b/src/components/request-info-card.tsx
@@ -34,9 +34,7 @@ export default function RequestInfoCard(props: Reimbursement) {
         </div>
         <div className="flex justify-center">
           <Image
-            src={
-              "https://ohiostate.pressbooks.pub/app/uploads/sites/160/h5p/content/5/images/image-5bd08790e1864.png" //placeholder, later use: props.receiptLink
-            }
+            src={props.receiptLink}
             width={500}
             height={500}
             alt="Receipt Picture"


### PR DESCRIPTION
## Developer: Brandon Wong

Closes #128 

### Pull Request Summary
Use reciptLink field for reimbursement objects to for receipt images from S3
Only the first three reimbursement objects currently have valid S3 image links

### Modifications
`src/components/request-info-card.tsx`: Use reciptLink field in reimbursement object

### Testing Considerations
Manually verified that S3 images appear in pop up

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/31b72ab8-7ac7-4a70-a284-be528974319e

<img width="409" alt="Screenshot 2024-04-30 at 11 40 23 AM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/cc9f3e13-3d41-4668-9c2d-6adc4c5d7f63">
<img width="772" alt="Screenshot 2024-04-30 at 11 41 05 AM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/73367549/06dd9faa-9626-4dfb-a9b9-b377e2921036">

