### PR TITLE
Add number of updates for sponsors john ieng

### DIFF
--- a/src/components/sponsored-org-card.tsx
+++ b/src/components/sponsored-org-card.tsx
@@ -6,6 +6,7 @@ export interface SponsoredOrgCardProps {
   organization: string;
   user: string;
   email: string;
+  updates?: number;
 }
 
 export default function SponsoredOrgCard({
@@ -13,7 +14,9 @@ export default function SponsoredOrgCard({
   organization,
   user,
   email,
+  updates,
 }: SponsoredOrgCardProps) {
+  // console.log(organization, " Updates:" + updates);
   return (
     <Card className="w-full h-72">
       <CardHeader className="pt-8 pl-4 pr-4 flex flex-row">
@@ -28,7 +31,13 @@ export default function SponsoredOrgCard({
           {organization}
         </CardTitle>
       </CardHeader>
+
       <CardContent className="pt-4 pl-9 pr-3 space-y-3">
+        {updates! > 0 && (
+          <span className="p-[8px_12px_8px_12px] bg-[#335543] rounded-[20px] text-white">
+            {updates === 1 ? `${updates} UPDATE` : `${updates} UPDATES`}
+          </span>
+        )}{" "}
         <div className="grid grid-cols-6 h-7 content-center">
           <Image
             className="col-span-1 self-center"

--- a/src/database/organization-schema.ts
+++ b/src/database/organization-schema.ts
@@ -8,7 +8,6 @@ interface Organization {
   logo?: string;
   reimbursements: Types.ObjectId[];
   status: string;
-  updates?: number;
 }
 
 const OrganizationSchema = new Schema({

--- a/src/database/organization-schema.ts
+++ b/src/database/organization-schema.ts
@@ -8,6 +8,7 @@ interface Organization {
   logo?: string;
   reimbursements: Types.ObjectId[];
   status: string;
+  updates?: number;
 }
 
 const OrganizationSchema = new Schema({


### PR DESCRIPTION
## Developer: {John Ieng}

Closes #142 

### Pull Request Summary

Count updates for each org and render them on a badge

### Modifications

`src/app/sponsored-organizations/page.tsx`: Add counting number of reimbursements for each individual organization
`src/components/sponsored-org-card.tsx`: Add badges component and number of updates prop

### Testing Considerations

Because there were no real reimbursements in the database, I manually created fake data to test the feature. 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="756" alt="Screenshot 2024-05-03 at 10 31 00 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/70654142/2a6b1404-6086-4179-9e6a-0d1630570b4c">

<img width="537" alt="Screenshot 2024-05-03 at 11 13 16 PM" src="https://github.com/hack4impact-calpoly/ecologistics-portal/assets/70654142/121825a0-3266-4d57-989c-25a69a549168">
