### PR TITLE
feat: got rid of double scrollbar

### DIFF
--- a/src/components/admin-table/admin-table.tsx
+++ b/src/components/admin-table/admin-table.tsx
@@ -73,7 +73,7 @@ export default function AdminTable() {
   const [error, setError] = React.useState<Error | null>(null);
 
   const [pageIndex, setPageIndex] = React.useState(0);
-  const [pageSize, setPageSize] = React.useState(9);
+  const [pageSize, setPageSize] = React.useState(8);
 
   React.useEffect(() => {
     fetchReimbursements()

--- a/src/components/sponsored-org-table/data-table.tsx
+++ b/src/components/sponsored-org-table/data-table.tsx
@@ -67,7 +67,7 @@ export function DataTable<TData, TValue>({
   const [globalFilter, setGlobalFilter] = useState("");
 
   const [pageIndex, setPageIndex] = React.useState(0);
-  const [pageSize, setPageSize] = React.useState(9);
+  const [pageSize, setPageSize] = React.useState(6);
 
   const table = useReactTable({
     data,


### PR DESCRIPTION
## Developer: Luke Waltz

Closes #162 

### Pull Request Summary

Removed double scrollbar from sponsored orgs table

### Modifications

reduced number of records per page on both tables so you don't need to scroll down to access the pagination nav buttons.

### Testing Considerations

it works

### Pull Request Checklist

- [X] Code is neat, readable, and works
- [X] Comments are appropriate
- [X] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [X] The developer name is specified
- [X] The summary is completed
- [X] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/66276398/b9afdfa3-f9c2-4fe1-9712-48fd3feee36e)

