### PR TITLE
feat: management popup design

### DIFF
--- a/src/components/admin-table/columns.tsx
+++ b/src/components/admin-table/columns.tsx
@@ -72,18 +72,16 @@ const OrganizationCell = ({ row }: { row: any }) => {
         </div>
       </DialogTrigger>
       <DialogContent>
-        <div className="border">
-          {selectedReimbursement ? (
-            <>
-              <ManageRequestCard
-                {...selectedReimbursement}
-                updateComment={updateComment}
-              />
-            </>
-          ) : (
-            <p>Loading reimbursement information...</p>
-          )}
-        </div>
+        {selectedReimbursement ? (
+          <>
+            <ManageRequestCard
+              {...selectedReimbursement}
+              updateComment={updateComment}
+            />
+          </>
+        ) : (
+          <p>Loading reimbursement information...</p>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/manage-request-card.tsx
+++ b/src/components/manage-request-card.tsx
@@ -11,61 +11,122 @@ import Reimbursement from "@/database/reimbursement-schema";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Pencil1Icon } from "@radix-ui/react-icons";
 
 export default function ManageRequestCard(
   props: Reimbursement & { updateComment: (input: string) => void },
 ) {
   const [comment, setComment] = useState(props.comment ?? "");
+  const [savedComment, setSavedComment] = useState(props.comment ?? "");
 
   return (
-    // Entire Card
-    <Card className="w-full rounded-2xl p-4">
-      {/* Title, status, amount, and date */}
-      <CardHeader>
-        <div className="flex justify-between items-center">
-          <CardTitle>{props.reportName}</CardTitle>
-          <StatusDropdown Status={props.status.toString()} />{" "}
+    <Card className="w-full rounded-2xl border-none">
+      <CardHeader className="flex flex-row justify-between items-top pb-3">
+        <div className="flex flex-col items-left">
+          <CardTitle className="text-xxl font-bold pb-3">
+            <p className="text-wrap text-ellipsis overflow-hidden max-w-[16rem]">
+              {props.reportName}
+            </p>
+          </CardTitle>
+          <CardDescription className="flex space-x-4 items-center text-black">
+            <div className="border border-black rounded-full py-1 px-3">
+              ${props.amount}
+            </div>
+            <div>{new Date(props.transactionDate).toLocaleDateString()}</div>
+          </CardDescription>
         </div>
-        <CardDescription className="flex space-x-4">
-          <div>${props.amount}</div>
-          <div>{new Date(props.transactionDate).toLocaleDateString()}</div>
-        </CardDescription>
+        <div className="flex flex-col w-[9rem]">
+          <StatusDropdown Status={props.status.toString()} />
+          <div className="text-center text-wrap text-ellipsis overflow-hidden">
+            {props.comment}
+          </div>
+        </div>
       </CardHeader>
-      {/* Description, recipient info, and image */}
-      <CardContent>
-        <div>
-          Receipt Description: {props.comment}
-          <br></br>
+      <CardContent className="space-y-1">
+        <p className="text-sm pb-5 text-wrap text-ellipsis overflow-hidden">
+          Request Description: {props.purpose}
+        </p>
+        <p className="text-base">
           Request For:<br></br>
-          {props.recipientName} &nbsp;
+        </p>
+        <p className="text-sm pb-4 text-wrap text-ellipsis overflow-hidden">
+          {props.recipientName}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
           {props.recipientEmail}
           <br></br>
-          {/* ssing payment type info from database? */}
-          Payment Type Info: {props.paymentMethod}
-        </div>
-        <div className="flex justify-center mt-[10px]">
-          <Image
-            src={props.receiptLink}
-            width={500}
-            height={500}
-            alt="Receipt Picture"
-            className="border border-blue-400 w-full"
-          />
-        </div>
-        <div className="mt-5">
-          <Textarea
-            placeholder="Additional comments"
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-          />
-          <Button
-            className="mt-2"
-            onClick={() => {
-              props.updateComment(comment);
-            }}
-          >
-            Update Comments
-          </Button>
+          Payment Type Info:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          {props.paymentMethod ? props.paymentMethod : "No Input"}
+        </p>
+
+        <Dialog>
+          <DialogTrigger asChild>
+            <div className="flex justify-center mt-[10px] max-w-[564px] max-h-[340px]">
+              <Image
+                src={props.receiptLink}
+                width={564}
+                height={340}
+                alt="Receipt Picture"
+                className="border border-gray-100 w-full object-cover object-center"
+              />
+            </div>
+          </DialogTrigger>
+          <DialogContent className="w-[100%]">
+            <Image
+              src={props.receiptLink}
+              width={564}
+              height={340}
+              alt="Receipt Picture"
+              objectFit=""
+              className="border border-gray-100 w-full"
+            />
+          </DialogContent>
+        </Dialog>
+        <div className="flex justify-end">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button className="mt-4 border-black h-7 px-2" variant="outline">
+                <Pencil1Icon className="w-4 h-4 mr-2" />
+                Edit
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="w-[100%]">
+              <Textarea
+                placeholder="Write Comment"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                className="w-full border border-gray-100 rounded-md p-2"
+              />
+              <DialogPrimitive.Close className="space-x-4 flex justify-end">
+                <Button
+                  type="submit"
+                  className="border-black h-7 px-2"
+                  onClick={() => {
+                    props.updateComment(comment);
+                    setSavedComment(comment);
+                  }}
+                >
+                  <p className="text-sm">Save</p>
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-black h-7 px-2"
+                  onClick={() => {
+                    setComment(savedComment);
+                  }}
+                >
+                  <p className="text-sm">Cancel</p>
+                </Button>
+              </DialogPrimitive.Close>
+            </DialogContent>
+          </Dialog>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Developer: Kyle Taschek

Closes #158 

### Pull Request Summary

Style the admin reimbursement info popup according to the Figma

### Modifications

`\src\components\admin-table\columns.tsx`: removed a div that added an extra border
`src\components\manage-request-card.tsx`: styled according to figma
- in addition to the figma design I added an image popup since the aspect ratio of the images is inconsistent
- admin comment is displayed under the status badge (unsure about where the comment should be displayed)
 


### Testing Considerations

- tested locally on desktop
- have not tested on a smaller screen like a laptop
- user flow for edit comments and clicking image

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/a5b8652c-df94-4a69-b63b-0ba70068e226)

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/9636bb57-505c-48db-a151-f4bc87cd5ac5)

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/70cb44af-f350-41e8-b5f4-3f3661ff34e5)

