### PR TITLE
Auto alert

### DIFF
--- a/src/app/api/alert/[id]/route.ts
+++ b/src/app/api/alert/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest, { params }: IParams) {
   await connectDB();
   const { id } = params;
   try {
-    const alerts: GetAlertResponse = await Alert.find({ name: id });
+    const alerts: GetAlertResponse = await Alert.find({ userId: id });
     return NextResponse.json(alerts);
   } catch (error) {
     const errorResponse: ErrorResponse = {

--- a/src/app/api/reimbursement/[id]/route.ts
+++ b/src/app/api/reimbursement/[id]/route.ts
@@ -68,7 +68,7 @@ export async function PUT(req: NextRequest, { params }: IParams) {
     ) {
       const newAlert: CreateAlertResponse = await new Alert({
         userId: currentReimbursement.clerkUserId,
-        title: "Reimbursement Update",
+        title: currentReimbursement.reportName,
         description: `Status: ${
           body.status || currentReimbursement.status
         }\nComment: ${body.comment || currentReimbursement.comment || "N/A"}`,

--- a/src/app/api/reimbursement/[id]/route.ts
+++ b/src/app/api/reimbursement/[id]/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { ErrorResponse } from "@/lib/error";
 import Reimbursement from "@/database/reimbursement-schema";
 import Status from "@/lib/enum";
+import { CreateAlertResponse } from "../../alert/[id]/route";
+import Alert from "@/database/alert-schema";
 
 export type UpdateReimbursementBody = {
   organization?: string;
@@ -58,6 +60,19 @@ export async function PUT(req: NextRequest, { params }: IParams) {
         error: "Status is not valid or undefined",
       };
       return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    if (
+      (body.status && body.status !== currentReimbursement.status) ||
+      (body.comment && body.comment !== currentReimbursement.comment)
+    ) {
+      const newAlert: CreateAlertResponse = await new Alert({
+        userId: currentReimbursement.clerkUserId,
+        title: "Reimbursement Update",
+        description: `Status: ${
+          body.status || currentReimbursement.status
+        }\nComment: ${body.comment || currentReimbursement.comment || "N/A"}`,
+      }).save();
     }
 
     const reimbursement: UpdateReimbursementResponse =

--- a/src/components/alert-dropdown.tsx
+++ b/src/components/alert-dropdown.tsx
@@ -1,7 +1,14 @@
 "use client";
-
-import { useState } from "react";
-import { BellIcon } from "@radix-ui/react-icons";
+import useSWR from "swr";
+import {
+  JSXElementConstructor,
+  PromiseLikeOfReactNode,
+  ReactElement,
+  ReactNode,
+  ReactPortal,
+  useState,
+} from "react";
+import { BellIcon, Cross2Icon } from "@radix-ui/react-icons";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -11,18 +18,33 @@ import {
   DropdownMenuSeparator,
 } from "components/ui/dropdown-menu";
 import NewUserButton from "./user-button";
-import { useUser } from "@clerk/nextjs";
+import { useAuth, useUser } from "@clerk/nextjs";
+import { Button } from "./ui/button";
 
 // Alert component on header
-export default function Alert() {
+export default function AlertIcon() {
   const { isSignedIn } = useUser();
+  const { userId } = useAuth();
   const [hasNewUpdates, setHasNewUpdates] = useState(true); // Assume there are new updates initially
 
-  const statusUpdates = [
-    { id: 1, text: "Request A approved" },
-    { id: 2, text: "Request B approved" },
-    { id: 3, text: "Request C denied" },
-  ];
+  const { data, error, mutate } = useSWR(
+    isSignedIn ? `/api/alert/${userId}` : null,
+    (...args) => fetch(...args).then((res) => res.json()),
+  );
+
+  const handleDeleteAlert = async (alertId: string) => {
+    try {
+      const res = await fetch(`api/alert/${userId}?id=${alertId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        throw new Error("Failed to fetch reimbursement");
+      }
+      mutate();
+    } catch (error) {
+      console.log(`error: ${error}`);
+    }
+  };
 
   const handleDropdownOpen = () => {
     setHasNewUpdates(false); // Resets the new updates state when dropdown is opened
@@ -32,9 +54,9 @@ export default function Alert() {
     return (
       <div className="z-10">
         <div className="flex space-x-4">
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={handleDropdownOpen}>
             <DropdownMenuTrigger asChild>
-              <button onClick={handleDropdownOpen}>
+              <button>
                 <div className="relative">
                   <BellIcon className="w-6 h-6" />
                   {hasNewUpdates && <span className="badge"></span>}
@@ -44,11 +66,46 @@ export default function Alert() {
             <DropdownMenuContent className="right-0">
               <DropdownMenuLabel>Recent Updates</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              {statusUpdates.map((statusUpdate) => (
-                <DropdownMenuItem key={statusUpdate.id}>
-                  {statusUpdate.text}
-                </DropdownMenuItem>
-              ))}
+              {data &&
+                !error &&
+                data.map(
+                  (
+                    alert: {
+                      title: string;
+                      description: string;
+                      _id: string;
+                    },
+                    index: number,
+                  ) => (
+                    <DropdownMenuItem key={index}>
+                      <div className="flex flex-row w-full justify-between items-center">
+                        <div>
+                          <div>{alert.title}</div>
+                          <div>
+                            {alert.description
+                              .split("\n")
+                              .map((line, index) => (
+                                <div key={index}>{line}</div>
+                              ))}
+                          </div>
+                        </div>
+                        <div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="w-6 h-6 flex justify-center items-center rounded-lg ml-3 hover:bg-red-400"
+                            onClick={(e) => {
+                              e.stopPropagation(); // Prevent event propagation to parent elements
+                              handleDeleteAlert(alert._id); // Call delete handler function
+                            }}
+                          >
+                            <Cross2Icon />
+                          </Button>
+                        </div>
+                      </div>
+                    </DropdownMenuItem>
+                  ),
+                )}
             </DropdownMenuContent>
           </DropdownMenu>
           <NewUserButton />


### PR DESCRIPTION
## Developer: Peter Chinh

Closes #138 

### Pull Request Summary

Made it so that changes to reimbursement status/comment creates a new alert. Made it so all of the users alerts are shown in the alert drop down and they can delete the alerts.

### Modifications

src/app/api/alert/[id]/route.ts - Changed name to userId to properly fetch using userId
src/app/api/reimbursement/[id]/route.ts - Added a condition under the PUT request that creates a new alert if status or comment is changed
src/components/alert-dropdown.tsx - Added a fetch and delete functionality for alerts. Also mapped and styled fetched alerts.

### Testing Considerations

Made a reimbursement with my clerk userID, perform a PUT request on the reimbursement where I changed the status to Paid, the alert should show up under the alert drop down, and pressing the cross button will remove it from the drop down.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [ ] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
Changing status
![Screenshot 2024-05-17 142716](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/113927794/8e0a0b09-15ac-4827-8472-c6b7e44f6fb2)
Receiving alert 
![Screenshot 2024-05-17 142732](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/113927794/193e9b36-40d6-445f-8de5-bbf985640a23)
Deleting alert
![Screenshot 2024-05-17 142757](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/113927794/b68d6994-550d-4da6-822d-bebeb5843e8c)
After deleting alert
![Screenshot 2024-05-17 142805](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/113927794/5633c220-6183-4d57-94dc-4748a6ba77ac)

