### PR TITLE
add: fix  scroll issues with sponsor table

### DIFF
--- a/src/components/admin-table/admin-table.tsx
+++ b/src/components/admin-table/admin-table.tsx
@@ -173,7 +173,7 @@ export default function AdminTable() {
   return (
     <>
       <ScrollArea
-        className={`h-[calc(90h-186px)] w-[calc(95vw-81px)] whitespace-nowrap`}
+        className={`h-[calc(90vh-186px)] w-[calc(95vw-81px)] whitespace-nowrap`}
       >
         <div className="flex justify-between space-x-1 w-full mb-5 text-gray-400">
           <div className="flex flex-col w-[25%] min-w-[20rem]">

--- a/src/components/sponsored-org-home.tsx
+++ b/src/components/sponsored-org-home.tsx
@@ -36,7 +36,7 @@ export default function SponsoredHomePage() {
   return (
     <main className="px-14 py-12 h-screen overflow-y-auto w-full">
       <div className="flex items-center justify-between">
-        <div className="flex gap-x-6 items-center">
+        <div className="flex gap-x-6">
           <h1 className="font-bold text-4xl">{orgInfo.name}</h1>
           <Popup
             name={orgInfo.name}
@@ -53,9 +53,7 @@ export default function SponsoredHomePage() {
           Request Reimbursement
         </Button>
       </div>
-      <div className="flex flex-col mt-8">
-        <SponsoredOrgTable />
-      </div>
+      <SponsoredOrgTable />
     </main>
   );
 }

--- a/src/components/sponsored-org-home.tsx
+++ b/src/components/sponsored-org-home.tsx
@@ -36,7 +36,7 @@ export default function SponsoredHomePage() {
   return (
     <main className="px-14 py-12 h-screen overflow-y-auto w-full">
       <div className="flex items-center justify-between">
-        <div className="flex gap-x-6">
+        <div className="flex gap-x-6 items-center">
           <h1 className="font-bold text-4xl">{orgInfo.name}</h1>
           <Popup
             name={orgInfo.name}

--- a/src/components/sponsored-org-table/data-table.tsx
+++ b/src/components/sponsored-org-table/data-table.tsx
@@ -77,9 +77,9 @@ export function DataTable<TData, TValue>({
   React.useEffect(() => {
     if (firstRender.current && row) {
       setPageSize(
-        Math.floor((window.innerHeight - 342) / row.height) <= 0
+        Math.floor((window.innerHeight - 380) / row.height) <= 0
           ? 3
-          : Math.floor((window.innerHeight - 342) / row.height),
+          : Math.floor((window.innerHeight - 380) / row.height),
       );
       firstRender.current = false;
     }
@@ -87,9 +87,9 @@ export function DataTable<TData, TValue>({
       if (row) {
         console.log(row.height);
         setPageSize(
-          Math.floor((window.innerHeight - 342) / row.height) <= 0
+          Math.floor((window.innerHeight - 380) / row.height) <= 0
             ? 3
-            : Math.floor((window.innerHeight - 342) / row.height),
+            : Math.floor((window.innerHeight - 380) / row.height),
         );
       }
     };
@@ -143,7 +143,7 @@ export function DataTable<TData, TValue>({
   };
   return (
     <>
-      <ScrollArea className={` whitespace-nowrap`}>
+      <ScrollArea className={`mt-8 whitespace-nowrap`}>
         <div className="flex justify-between space-x-1 w-full py-4">
           <DebouncedInput
             value={globalFilter ?? ""}
@@ -166,7 +166,7 @@ export function DataTable<TData, TValue>({
             />
           </div>
         </div>
-        <div className="rounded-md border flex max-h-[calc(100dvh-250px)]">
+        <div className="rounded-md border flex max-h-[calc(100dvh-330px)]">
           <Table>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (

--- a/src/components/sponsored-org-table/data-table.tsx
+++ b/src/components/sponsored-org-table/data-table.tsx
@@ -29,6 +29,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
 import { Button } from "@/components/ui/button";
 import { DebouncedInput } from "../ui/custom/debounced-input";
@@ -68,6 +69,33 @@ export function DataTable<TData, TValue>({
 
   const [pageIndex, setPageIndex] = React.useState(0);
   const [pageSize, setPageSize] = React.useState(6);
+  const firstRender = React.useRef(true);
+  const row = document
+    .getElementById("sponsored-org-table-row")
+    ?.getBoundingClientRect();
+
+  React.useEffect(() => {
+    if (firstRender.current && row) {
+      setPageSize(
+        Math.floor((window.innerHeight - 342) / row.height) <= 0
+          ? 3
+          : Math.floor((window.innerHeight - 342) / row.height),
+      );
+      firstRender.current = false;
+    }
+    const handleWindowResize = () => {
+      if (row) {
+        console.log(row.height);
+        setPageSize(
+          Math.floor((window.innerHeight - 342) / row.height) <= 0
+            ? 3
+            : Math.floor((window.innerHeight - 342) / row.height),
+        );
+      }
+    };
+    window.addEventListener("resize", handleWindowResize);
+    return () => window.removeEventListener("resize", handleWindowResize);
+  }, [row, firstRender]);
 
   const table = useReactTable({
     data,
@@ -114,82 +142,86 @@ export function DataTable<TData, TValue>({
     });
   };
   return (
-    <div>
-      <div className="flex justify-between py-4">
-        <DebouncedInput
-          value={globalFilter ?? ""}
-          onChange={(value) => setGlobalFilter(String(value))}
-          className="px-2 text-sm flex-grow w-100 mt-4 border rounded"
-          placeholder="Search all columns..."
-        />
-        <TableColumnFilterDropdown
-          table={table}
-          identifier="status"
-          title="Status"
-          values={["Pending", "Declined", "On Hold", "Paid"]}
-          placeholder=""
-        />
-        <div>
-          <Label className="text-xs pl-3">Date Range</Label>
-          <DatePickerWithRange
-            handleChange={handleDateRangeChange}
-            className="ml-2 self-end"
+    <>
+      <ScrollArea className={` whitespace-nowrap`}>
+        <div className="flex justify-between space-x-1 w-full py-4">
+          <DebouncedInput
+            value={globalFilter ?? ""}
+            onChange={(value) => setGlobalFilter(String(value))}
+            className="px-2 text-sm flex-grow w-100 mt-4 border rounded"
+            placeholder="Search all columns..."
           />
+          <TableColumnFilterDropdown
+            table={table}
+            identifier="status"
+            title="Status"
+            values={["Pending", "Declined", "On Hold", "Paid"]}
+            placeholder=""
+          />
+          <div className="flex flex-col">
+            <Label className="text-xs pl-1 min-w-[16rem]">Date Range</Label>
+            <DatePickerWithRange
+              handleChange={handleDateRangeChange}
+              className="ml-2 self-end"
+            />
+          </div>
         </div>
-      </div>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
+        <div className="rounded-md border flex max-h-[calc(100dvh-250px)]">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    );
+                  })}
                 </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
-                  No results.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows?.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    id="sponsored-org-table-row"
+                    key={row.id}
+                    data-state={row.getIsSelected() && "selected"}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="h-24 text-center"
+                  >
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
       <Pagination>
         <PaginationContent>{renderPagination()}</PaginationContent>
       </Pagination>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Developer: Kyle Taschek
Closes #183 

### Pull Request Summary

Fix the horizontal and vertical scrolling problems of the sponsored org table

### Modifications

- `src\components\admin-table\admin-table.tsx`: fix height error in last pr for admin table
- `src/components/sponsored-org-home.tsx`: touch up styling
- `src/components/sponsored-org-table/data-table.tsx`: help remove scroll bar issues with different size windows

### Testing Considerations

Tested at smaller sizes and fixed horizontal scroll issue completely

#### However, When the page is too small width wise, this creates another issue because the spacing of the buttons and sponsored org name overflow creates issues with the sizing of the table.
I was not sure this was in the scope of my assignment.

Note: The original vertical scroll bar is present because of sidebar sizing which is kind of hard to standardize since each page view has a different height 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

Small Window display:
![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/2c7b3f60-f4f3-4669-9c85-2af9f8d5720b)

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/28a998f2-e05b-4957-976b-3db7dd908927)

Normal window display:
![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/7178c2af-1d54-4f9b-bd84-ef5bcb3f444a)

Problematic sizing:
![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/be9547ee-db43-4e59-96d0-d4f88d7ebbb4)

