### PR TITLE
X button overlap Issue

### DIFF
--- a/src/components/admin/manage-request-card.tsx
+++ b/src/components/admin/manage-request-card.tsx
@@ -85,6 +85,7 @@ export default function ManageRequestCard(props: ManageRequestCardProps) {
                 </Button>
               </DialogTrigger>
               <DialogContent className="w-[100%]">
+                <div className="font-bold">Change Comment</div>
                 <Textarea
                   placeholder="Write Comment"
                   value={comment}

--- a/src/components/admin/manage-request-card.tsx
+++ b/src/components/admin/manage-request-card.tsx
@@ -85,7 +85,7 @@ export default function ManageRequestCard(props: ManageRequestCardProps) {
                 </Button>
               </DialogTrigger>
               <DialogContent className="w-[100%]">
-                <div className="font-bold ">Change Comment</div>
+                <div className="font-bold ">Edit Comment</div>
                 <Textarea
                   placeholder="Write Comment"
                   value={comment}

--- a/src/components/admin/manage-request-card.tsx
+++ b/src/components/admin/manage-request-card.tsx
@@ -85,7 +85,7 @@ export default function ManageRequestCard(props: ManageRequestCardProps) {
                 </Button>
               </DialogTrigger>
               <DialogContent className="w-[100%]">
-                <div className="font-bold">Change Comment</div>
+                <div className="font-bold ">Change Comment</div>
                 <Textarea
                   placeholder="Write Comment"
                   value={comment}


### PR DESCRIPTION
## Developer: Kyle Taschek

Closes #{ISSUE NUMBER HERE}

### Pull Request Summary

Remove the overlap of the text box with the close button on management pop up card in the comment edit section

### Modifications

Added Text saying "Change Comment" to prevent overlap

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/hack4impact-calpoly/ecologistics-portal/assets/94573630/eecc220f-0554-4554-a909-e6abb710ccf9)
